### PR TITLE
fix make proto fail issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ clean:
 	rm -f $(LIB) $(LIB_OBJ) $(BIN) $(BIN_OBJ) $(PROTO_HEADER) $(PROTO_SRC)
 
 proto:
-	cd src && sh compile_proto.sh
+	cd src && sh compile_proto.sh ${PROTOBUF_DIR}/include
 
 rebuild: clean all
 

--- a/src/compile_proto.sh
+++ b/src/compile_proto.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-PROTO_INCLUDE=./
+PROTO_INCLUDE=$1
 
-protoc --proto_path=. --proto_path=$PROTO_INCLUDE --proto_path=/usr/local/include --cpp_out=. \
+protoc --proto_path=. --proto_path=${PROTO_INCLUDE} --proto_path=/usr/local/include --cpp_out=. \
 sofa/pbrpc/rpc_meta.proto sofa/pbrpc/rpc_option.proto sofa/pbrpc/builtin_service.proto
 


### PR DESCRIPTION
"make proto" may fail due to PROTO_INCLUDE not pointed to protobuf install dir