### PR TITLE
fix error when using setuptools

### DIFF
--- a/python/sofa/__init__.py
+++ b/python/sofa/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
```
error: Namespace package problem: sofa is a namespace package, but its
__init__.py does not call declare_namespace()! Please fix it.
(See the setuptools manual under "Namespace Packages" for details.)
```
